### PR TITLE
Change type of LuminosityPercentage to int from byte

### DIFF
--- a/nanoFramework.M5StickCommon/Screen.cs
+++ b/nanoFramework.M5StickCommon/Screen.cs
@@ -19,7 +19,7 @@ namespace nanoFramework.M5Stick
         private const int DataCommand = 23;
         private const int Reset = 18;
         private static Axp192 _power;
-        private static byte _lumi;
+        private static int _lumi;
         private static bool _isInitialized = false;
         
         /// <summary>
@@ -53,7 +53,7 @@ namespace nanoFramework.M5Stick
         /// <summary>
         /// Enables or disables the screen.
         /// </summary>
-        public static new bool Enabled
+        public new static bool Enabled
         {
             get => IsEnabled;
 
@@ -68,7 +68,7 @@ namespace nanoFramework.M5Stick
         /// Sets or gets the screen luminosity.
         /// </summary>
         /// <remarks> On M5Stick, anything less than 20% will be fully black</remarks>
-        public static new byte LuminosityPercentage
+        public new static int LuminosityPercentage
         {
             get => _lumi;
 
@@ -76,8 +76,8 @@ namespace nanoFramework.M5Stick
             {
                 // For M5Stick, values from 8 to 12 are working fine
                 // 2.5 V = dark, 3.0 V full luminosity
-                _lumi = (byte)(value > 100 ? 100 : _lumi);
-                _power.LDO3OutputVoltage = ElectricPotential.FromVolts((byte)(_lumi * 0.5 / 100.0 + 2.5));
+                _lumi = value > 100 ? 100 : value;
+                _power.LDO3OutputVoltage = ElectricPotential.FromVolts(_lumi * 0.5 / 100.0 + 2.5);
             }
         }
     }


### PR DESCRIPTION
The LuminosityPercentage stayed at 0 when initializing the screen on M5StickC Plus.

## Description

I couldn't get my display working so debugged it to the setter of the Screen.LuminosityPercentage. This PR changes the type to an int and updates the setter.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
