### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These NuGet packages provide a support for M5Stack products:
 
 IMPORTANT: The M5Stack NuGet Package must only be used for application targeting the M5 Stack's Core (gray); the other 3 NuGets must be used individually depending on your target according its name.
 NOTE1: Before trying to add NuGet packages to your projects and/or before flashing the devices (see next section) using MS Visual Studio (VS), open VS > Tools > Options > NuGet Package Manager > Package Sources  and make sure that it contains an entry pointing to https://api.nuget.org/v3/index.json , otherwise add it.
-NOTE2: When invoking VS > Project > Manage NuGet Packages ... make sure that the "include prerelease" checkbox is clicked/selected and that in the Package source drop-down menu (right upper corner) "nuget.org" is selected.  
+NOTE2: When invoking VS > Project > Manage NuGet Packages make sure that in the Package source drop-down menu (right upper corner) "nuget.org" is selected. Also if you're using preview version the "include prerelease" checkbox should be clicked/selected as well.  
 
 The NuGets bring support for the screens as well and require to be flashed with the proper image (using dotnet CLI):
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Screen.Write(0, 0, 10, 10, toSend);
 ```
 
 The Console class works in a similar way as the classic `System.Console`. In order to use it you have to reference it using the fully qualified name of the methods, like this:
-
 e.g. Debug.WriteLine("Hello from nanoFramework 1!");
 and Console.Write("Hello from nanoFramework 2!"); will both write on the Debugger output , not on the target device screen; in order to do that
 you have to use the nanoFramework.Console instead e.g.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@
 
 ## Usage
 
-Those 4 nugets provide a support for the M5 Stack's Core (gray) [M5Stack](https://docs.m5stack.com/en/products?id=core), [M5StickC](https://docs.m5stack.com/en/core/m5stickc), [M5StickCPlus](https://docs.m5stack.com/en/core/m5stickc_plus) and [M5Core2](https://docs.m5stack.com/en/core/core2).
+These NuGet packages provide a support for M5Stack products: 
+- [Core (gray)](https://docs.m5stack.com/en/products?id=core)
+- [M5StickC](https://docs.m5stack.com/en/core/m5stickc)
+- [M5StickCPlus](https://docs.m5stack.com/en/core/m5stickc_plus) 
+- [M5Core2](https://docs.m5stack.com/en/core/core2).
 
 IMPORTANT: The M5Stack NuGet Package must only be used for application targeting the M5 Stack's Core (gray); the other 3 NuGets must be used individually depending on your target according its name.
 NOTE1: Before trying to add NuGet packages to your projects and/or before flashing the devices (see next section) using MS Visual Studio (VS), open VS > Tools > Options > NuGet Package Manager > Package Sources  and make sure that it contains an entry pointing to https://api.nuget.org/v3/index.json , otherwise add it.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ NOTE2: When invoking VS > Project > Manage NuGet Packages make sure that in the 
 The NuGets bring support for the screens as well and require to be flashed with the proper image (using dotnet CLI):
 
 ```shell
-# Replace the com port number by your COM port (on WIndows check it with the Device Manager) 
+# Replace `COM3` with the appropriate number of the COM port to which your device is connected. (on Windows you can check this in the Device Manager).
 # For the M5Stack:
 nanoff --target M5Stack --update --preview --serialport COM3
 # For the M5StickC:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Screen.Write(0, 0, 10, 10, toSend);
 ```
 
 The Console class works in a similar way as the classic `System.Console`. In order to use it you have to reference it using the fully qualified name of the methods, like this:
-and Console.Write("Hello from nanoFramework 2!"); will both write on the Debugger output , not on the target device screen; in order to do that
 
 ```csharp
 nanoFramework.Console.Clear();

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Screen.Write(0, 0, 10, 10, toSend);
 
 The Console class works in a similar way as the classic `System.Console`. In order to use it you have to reference it using the fully qualified name of the methods, like this:
 and Console.Write("Hello from nanoFramework 2!"); will both write on the Debugger output , not on the target device screen; in order to do that
-you have to use the nanoFramework.Console instead e.g.
 
 ```csharp
 nanoFramework.Console.Clear();

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ using nanoFramework;
 
 ### Screen
 
-The only thing you need to do to access the screen is to initialize it; nevetheless this is also target specific e.g.:
+The only thing you need to do to access the screen is to initialize it (please note that `InitializeScreen()` it's target specific) e.g.:
 
 For Core:
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Screen.Write(0, 0, 10, 10, toSend);
 ```
 
 The Console class works in a similar way as the classic `System.Console`. In order to use it you have to reference it using the fully qualified name of the methods, like this:
-e.g. Debug.WriteLine("Hello from nanoFramework 1!");
 and Console.Write("Hello from nanoFramework 2!"); will both write on the Debugger output , not on the target device screen; in order to do that
 you have to use the nanoFramework.Console instead e.g.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ nanoff --target M5StickCPlus --update --preview --serialport COM3 --baud 115200
 # For the M5Core2:
 nanoff --target M5Core2 --update --preview --serialport COM3
 ```
-NOTE3: If the nanoff commands fail, make sure you did what is written on NOTE1.
+NOTE3: If the nanoff commands fails, make sure you have followed instruction from NOTE1 above.
 
 Once you have the nugets, you can then enjoy accessing the screen, the accelerometer, get a Grove I2C connecter, add events on the buttons. And you don't even need to think about anything, all is done for you in the most transparent way!
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@
 
 ## Usage
 
-Those 3 nugets provide a support for the [M5Stack](https://docs.m5stack.com/en/products?id=core), [M5StickC](https://docs.m5stack.com/en/core/m5stickc), [M5StickCPlus](https://docs.m5stack.com/en/core/m5stickc_plus) and [M5Core2](https://docs.m5stack.com/en/core/core2).
+Those 4 nugets provide a support for the M5 Stack's Core (gray) [M5Stack](https://docs.m5stack.com/en/products?id=core), [M5StickC](https://docs.m5stack.com/en/core/m5stickc), [M5StickCPlus](https://docs.m5stack.com/en/core/m5stickc_plus) and [M5Core2](https://docs.m5stack.com/en/core/core2).
 
-They bring support for the screens as well and require to be flashed with the proper image:
+IMPORTANT: The M5Stack NuGet Package must only be used for application targeting the M5 Stack's Core (gray); the other 3 NuGets must be used individually depending on your target according its name.
+NOTE1: Before trying to add NuGet packages to your projects and/or before flashing the devices (see next section) using MS Visual Studio (VS), open VS > Tools > Options > NuGet Package Manager > Package Sources  and make sure that it contains an entry pointing to https://api.nuget.org/v3/index.json , otherwise add it.
+NOTE2: When invoking VS > Project > Manage NuGet Packages ... make sure that the "include prerelease" checkbox is clicked/selected and that in the Package source drop-down menu (right upper corner) "nuget.org" is selected.  
+
+The NuGets bring support for the screens as well and require to be flashed with the proper image (using dotnet CLI):
 
 ```shell
-# Replace the com port number by your COM port
+# Replace the com port number by your COM port (on WIndows check it with the Device Manager) 
 # For the M5Stack:
 nanoff --target M5Stack --update --preview --serialport COM3
 # For the M5StickC:
@@ -36,6 +40,7 @@ nanoff --target M5StickCPlus --update --preview --serialport COM3 --baud 115200
 # For the M5Core2:
 nanoff --target M5Core2 --update --preview --serialport COM3
 ```
+NOTE3: If the nanoff commands fail, make sure you did what is written on NOTE1.
 
 Once you have the nugets, you can then enjoy accessing the screen, the accelerometer, get a Grove I2C connecter, add events on the buttons. And you don't even need to think about anything, all is done for you in the most transparent way!
 
@@ -43,12 +48,18 @@ Once you have the nugets, you can then enjoy accessing the screen, the accelerom
 
 In the samples below, we'll use either M5Stack, either M5Stick as examples, they are all working in a very similar way.
 
+### namespaces
+
+Make sure you add the proper namespaces reference to your C# program header e.g.
+using nanoFramework;
+
 ### Screen
 
-The only thing you need to do to access the screen is to initialize it:
+The only thing you need to do to access the screen is to initialize it; nevetheless this is also target specific e.g.:
 
 ```csharp
-M5Stack.InitializeScreen();
+For Core use: M5Stack.InitializeScreen();
+For StickCPlus use: nanoFramework.M5Stick.M5StickCPlus.InitializeScreen();
 ```
 
 Once you've initialized it, you can access both a `Screen` static class and a `Console` static class.
@@ -69,22 +80,26 @@ for (int i = 0; i < toSend.Length; i++)
 Screen.Write(0, 0, 10, 10, toSend);
 ```
 
-The Console class works in a similar way as the classic `System.Console`:
+The Console class works in a similar way as the classic `System.Console` i.e. it writes to the remote Debbuger output on the host (VS):
+
+e.g. Debug.WriteLine("Hello from nanoFramework 1!");
+and Console.Write("Hello from nanoFramework 2!"); will both write on the Debugger output , not on the target device screen; in order to do that
+you have to use the nanoFramework.Console instead e.g.
 
 ```csharp
-Console.Clear();
+nanoFramework.Console.Clear();
 
 // Test the console display
-Console.Write("This is a short text. ");
-Console.ForegroundColor = Color.Red;
-Console.WriteLine("This one displays in red after the previous one and is already at the next line.");
-Console.BackgroundColor = Color.Yellow;
-Console.ForegroundColor = Color.RoyalBlue;
-Console.WriteLine("And this is blue on yellow background");
-Console.ResetColor();
-Console.CursorLeft = 0;
-Console.CursorTop = 8;
-Console.Write("This is white on black again and on 9th line");
+nanoFramework.Console.Write("This is a short text. ");
+nanoFramework.Console.ForegroundColor = nanoFramework.Presentation.Media.Color.Red;
+nanoFramework.Console.WriteLine("This one displays in red after the previous one and is already at the next line.");
+nanoFramework.Console.BackgroundColor = nanoFramework.Presentation.Media.Color.Yellow;
+nanoFramework.Console.ForegroundColor = nanoFramework.Presentation.Media.Color.RoyalBlue;
+nanoFramework.Console.WriteLine("And this is blue on yellow background");
+nanoFramework.Console.ResetColor();
+nanoFramework.Console.CursorLeft = 0;
+nanoFramework.Console.CursorTop = 8;
+nanoFramework.Console.Write("This is white on black again and on 9th line");
 ```
 
 > Note: You can change the default font as well, you need to provide it as a property. The Cursor positions are calculated with the largest possible character.
@@ -122,11 +137,11 @@ M5StickC.M5Button.Holding += (sender, e) =>
 };
 ```
 
-> Note: The M5Core2 has touch screen and the buttons are part of it. So far .NET nanoFramework does not have the support for them and thus, they are not supported yet. PR to improve this situation welcome!
+> Note: The M5Core2 has touch screen and the buttons are "virtual"". At the time of this writting the .NET nanoFramework distributed team is already implementing and testing the touch-screen (touch-panel) functionality (will be released soon).  
 
 ### Power management
 
-Both M5Stack and M5StickC/CPlus are exposing their power management elements. It is not recommended to change any default value except if you know what you are doing.
+The M5Stack (Core) and M5StickC/CPlus are exposing their power management elements. It is not recommended to change any default value except if you know what you are doing.
 
 Please refer to the detailed examples for the [AXP192](https://github.com/nanoframework/nanoFramework.IoT.Device/blob/develop/devices/Axp192/README.md) used in the M5StickC/CPlus; M5Core2 and [IP5306](https://github.com/nanoframework/nanoFramework.IoT.Device/blob/develop/devices/Ip5306/README.md) for the M5Stack.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ M5StickC.M5Button.Holding += (sender, e) =>
 };
 ```
 
-> Note: The M5Core2 has touch screen and the buttons are "virtual"". At the time of this writting the .NET nanoFramework distributed team is already implementing and testing the touch-screen (touch-panel) functionality (will be released soon).  
+> Note: The M5Core2 has touch screen and the buttons are "virtual"". At the time of this writing the .NET nanoFramework team is implementing and testing the touch-screen (touch-panel) functionality (will be released soon).
 
 ### Power management
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ for (int i = 0; i < toSend.Length; i++)
 Screen.Write(0, 0, 10, 10, toSend);
 ```
 
-The Console class works in a similar way as the classic `System.Console` i.e. it writes to the remote Debbuger output on the host (VS):
+The Console class works in a similar way as the classic `System.Console`. In order to use it you have to reference it using the fully qualified name of the methods, like this:
 
 e.g. Debug.WriteLine("Hello from nanoFramework 1!");
 and Console.Write("Hello from nanoFramework 2!"); will both write on the Debugger output , not on the target device screen; in order to do that

--- a/README.md
+++ b/README.md
@@ -61,9 +61,16 @@ using nanoFramework;
 
 The only thing you need to do to access the screen is to initialize it; nevetheless this is also target specific e.g.:
 
+For Core:
+
 ```csharp
-For Core use: M5Stack.InitializeScreen();
-For StickCPlus use: nanoFramework.M5Stick.M5StickCPlus.InitializeScreen();
+M5Stack.InitializeScreen();
+```
+
+For StickCPlus:
+
+```csharp
+M5StickCPlus.InitializeScreen();
 ```
 
 Once you've initialized it, you can access both a `Screen` static class and a `Console` static class.


### PR DESCRIPTION
## Description
- Documentation improvements according current state of matter e.g. Console is the debugger System console and not the the device one nanoFramework.Console. 
- Additional notes added for the newbies to have an easier start. 
- Changes on all screen initialization and  Console related code tested on a StickCPlus....screen initialization for Core2 and StickC must be added yet

## Motivation and Context
- Documentation was not in-synch with implementation
- Documentation made it difficult for the newbies to know where to start 
- M5Stack wrongly used to refer to Core (gray), M5Stack is the name of the company.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Changes on all screen initialization and  Console related code tested on a StickCPlus (Visual Studio 2022 Commnity on WIndows 10).

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
