### PR TITLE
Resolve missing LiftUp touch event for Core2

### DIFF
--- a/M5StackCommon/Core2ToughCommon.cs
+++ b/M5StackCommon/Core2ToughCommon.cs
@@ -257,6 +257,8 @@ namespace nanoFramework.M5Stack
                     touchCategory = CheckIfInButtons(dp.Point2.X, dp.Point2.Y, TouchEventCategory.DoubleTouch);
                     touchCategory = dp.Point2.Event == Event.Contact ? touchCategory | TouchEventCategory.Moving : touchCategory;
                     TouchEvent?.Invoke(_touchController, new TouchEventArgs() { TimeStamp = DateTime.UtcNow, EventCategory = EventCategory.Touch, TouchEventCategory = touchCategory, X = dp.Point2.X, Y = dp.Point2.Y, Id = dp.Point2.TouchId });
+                } else if (touchNumber==0) {
+                    TouchEvent?.Invoke(_touchController, new TouchEventArgs() { TimeStamp = DateTime.UtcNow, EventCategory = EventCategory.Touch, TouchEventCategory = TouchEventCategory.LiftUp , X = _lastPoint.X, Y = _lastPoint.Y });
                 }
 
                 // This is necessary to give time to the touch sensor


### PR DESCRIPTION
### Description
LiftUp touchcreen message never being received from Core2 touchscreen.

### Motivation and Context
This is using sample program available [here ](https://github.com/nanoframework/nanoFramework.M5Stack/tree/main/Tests/M5Core2TestApp)
Issue was ThreadTouchCallback was set to only pass on the event when there are 1 or 2 touches ongoing.
LiftUp obviously has 0 touches. I use the _lastPoint to pass on coordinates.

### How Has This Been Tested?
Tested locally on my Core2, again using sample program. I now have liftup messages being passed.
```
Event Catagory: Moving...
Touch Panel Event Received Category= 120 Subcategory= 16
TOUCHED at (x,y): (177,169), Id=0
Event Catagory: Moving...
Touch Panel Event Received Category= 120 Subcategory= 16
TOUCHED at (x,y): (164,160), Id=0
Event Catagory: Moving...
Touch Panel Event Received Category= 120 Subcategory= 32
TOUCHED at (x,y): (161,158), Id=0
Event Catagory: Lift Up.
````

### Screenshots

### Types of changes
- [x]  Bug fix (non-breaking change which fixes an issue with code or algorithm)

### Checklist:
- [x]  My code follows the code style of this project (only if there are changes in source code).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x]  I have tested everything locally and all new and existing tests passed (only if there are changes in source code).